### PR TITLE
Improve testing method

### DIFF
--- a/piwikapi/tests/__init__.py
+++ b/piwikapi/tests/__init__.py
@@ -1,0 +1,27 @@
+import unittest
+import doctest
+import sys
+
+
+
+def all_tests_suite():
+    suite = unittest.TestLoader().loadTestsFromNames([
+        'piwikapi.tests.analytics',
+        'piwikapi.tests.ecommerce',
+        'piwikapi.tests.goals',
+        'piwikapi.tests.request',
+        'piwikapi.tests.tracking',
+    ])
+    return suite
+
+def main():
+    runner = unittest.TextTestRunner(verbosity=1 + sys.argv.count('-v'))
+    suite = all_tests_suite()
+    raise SystemExit(not runner.run(suite).wasSuccessful())
+
+
+if __name__ == '__main__':
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    main()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,28 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from distutils.core import Extension, Command
+
+
+class TestCommand(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import sys, subprocess
+        raise SystemExit(
+            subprocess.call([sys.executable,
+                # Turn on deprecation warnings
+                '-Wd',
+                'piwikapi/tests/__init__.py']))
+
+cmdclass = dict(test=TestCommand)
+kw = dict(cmdclass=cmdclass)
 setup(
     name = "piwikapi",
     version = "0.2.2",
@@ -12,8 +34,8 @@ setup(
     long_description = open("README.rst").read(),
     license = "BSD",
     url = "http://github.com/nkuttler/python-piwikapi",
-    packages = ['piwikapi'],
-    include_package_data = True,
+    packages = ['piwikapi', 'piwikapi.tests'],
+#    include_package_data = True,
     classifiers = [
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
@@ -22,5 +44,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
-    zip_safe = True,
+    **kw
+#    zip_safe = True,
 )


### PR DESCRIPTION
I think its common practice for Python projects to execute tests by calling `python setup.py test`, this was not possible before so I implemented this. Not sure if some lines in base.py are unnecessary now, so you might want to check that.

It would be great to add automatic test builds using Travis-CI to this project. If you like I can work on a solution to get a running Piwik installation onto the Travis-CI server so we can automatically test the library each time a commit happens.

Changes: 
- Changed setup.py to support the test command. You can now run tests via `python setup.py test`
- Defined test suite in `piwikapi/tests/__init__.py`
